### PR TITLE
Docs link

### DIFF
--- a/src/components/FooterBar.vue
+++ b/src/components/FooterBar.vue
@@ -7,7 +7,7 @@
             .title.is-5 Documentation
             ul
               li
-                a(href="https://github.com/Discord4J/Discord4J/wiki", target="_blank") Discord4J Docs
+                a(href="https://docs.discord4j.com", target="_blank") Discord4J Docs
               li
                 a(href="http://javadoc.io/doc/com.discord4j/discord4j-core/", target="_blank") Javadocs
           .column

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -11,7 +11,7 @@
           span(aria-hidden="true")
       .navbar-menu(:class="{'is-active': showNav}")
         .navbar-end
-          a(href="https://github.com/Discord4J/Discord4J/wiki", target="_blank").navbar-item Documentation
+          a(href="https://docs.discord4j.com", target="_blank").navbar-item Documentation
           router-link(to="/blog").navbar-item Blog
           span.navbar-item
             a.button.is-outlined(href="https://github.com/Discord4J/Discord4J")


### PR DESCRIPTION
**Description**: Changes the href attribute on the Documentation \<a\> element in the NavBar and FooterBar to the new Discord4J Documentation website

**Justification**: Instead of linking to the GitHub Wiki, these links should redirect the user to the new Documentation website.